### PR TITLE
Use environment variable to set qd.datadir

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,9 @@
 .onLoad <- function(libname, pkgname) {
-  dataDirectory <- file.path(path.expand("~"),"QuaDramA","Data2")
+  if (!Sys.getenv(c("QUADRAMA_DIR")) == "") {
+    dataDirectory <- Sys.getenv(c("QUADRAMA_DIR"))
+  } else {
+    dataDirectory <- file.path(path.expand("~"),"QuaDramA","Data2")
+  }
   collectionDirectory <- file.path(dataDirectory,"collections")
   options(qd.datadir=dataDirectory)
   options(qd.collectionDirectory=collectionDirectory)


### PR DESCRIPTION
The data directory still defaults to `~/QuaDramA/Data2/`, but the user can now overwrite this behaviour by setting a global custom path using the environment variable `QUADRAMA_DIR`

Example use case:
```
$ export QUADRAMA_DIR="$XDG_DATA_DIR/QuaDramA/Data2"
```